### PR TITLE
Fix skill image import paths and update tsconfig options

### DIFF
--- a/src/Media/Skills/index.tsx
+++ b/src/Media/Skills/index.tsx
@@ -1,6 +1,6 @@
 // Export all tab images
-export { default as Combat } from '@media/skills/Combat.png'
-export { default as Farming } from '@media/skills/Farming.png'
-export { default as Fishing } from '@media/skills/Fishing.png'
-export { default as Foraging } from '@media/skills/Foraging.png'
-export { default as Mining } from '@media/skills/Mining.png'
+export { default as Combat } from '@media/Skills/Combat.png'
+export { default as Farming } from '@media/Skills/Farming.png'
+export { default as Fishing } from '@media/Skills/Fishing.png'
+export { default as Foraging } from '@media/Skills/Foraging.png'
+export { default as Mining } from '@media/Skills/Mining.png'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,8 @@
     "strict": true,
     "jsx": "react-jsx",
     "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Corrected the import paths in src/Media/Skills/index.tsx to use 'Skills' instead of 'skills'. Updated tsconfig.json to add 'allowImportingTsExtensions' and 'noEmit' options for improved TypeScript configuration.