### PR TITLE
Backwards compatibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'; 
-import Main from './Components/Main/Main'
+import Main from './Components/Main/Main.tsx'
 import './App.css'
 import './Components/tabs-css/tabs.css'
 import { Route, Routes } from "react-router-dom";

--- a/src/Components/Main/Main.tsx
+++ b/src/Components/Main/Main.tsx
@@ -1,5 +1,5 @@
 import Stats from '../stats/stats.js'
-import Viewer from '../Viewer/Viewer'
+import Viewer from '../Viewer/Viewer.tsx'
 import Logo from '@media/logo.png';
 import fb from '@media/Social/fb.png'
 import kofi from '@media/Social/kofi.png'

--- a/src/Components/Skills/index.tsx
+++ b/src/Components/Skills/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import SkillContainer from './SkillContainer/SkillContainer'
+import SkillContainer from './SkillContainer/SkillContainer.tsx'
 import {Farming, Mining, Foraging, Fishing, Combat} from '@media/Skills'
 import type { experienceType } from 'types/displayDataTypes'
 import './Skills.css'

--- a/src/Components/Viewer/Viewer.tsx
+++ b/src/Components/Viewer/Viewer.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import Junimo6 from '@media/Junimo6.png';
-import useLoadSaveFile from '@hooks/useLoadSaveFile';
+import useLoadSaveFile from '@hooks/useLoadSaveFile.tsx'; 
 
 interface ViewerProps {
     UpdatePlayerData: (playerData: any) => void;

--- a/src/Utility/Parsers/parseCraftingItems.ts
+++ b/src/Utility/Parsers/parseCraftingItems.ts
@@ -1,7 +1,7 @@
 import { CraftingRec } from "@utility/JSON"
 import type { achievementType, generalFormatedItemType, itemsCraftedType } from "types/displayDataTypes"
 import type { itemsType } from "types/savefile"
-import { GetImages, ValidateKnown } from "./Utils"
+import { GetImages, ValidateKnown } from "./Utils.ts"
 import { DIY, Artisan, MasterCraft } from "@media/Achievements";
 
 let CraftingAchievements = [{

--- a/src/Utility/Parsers/parseCropItems.ts
+++ b/src/Utility/Parsers/parseCropItems.ts
@@ -1,7 +1,7 @@
 import { CraftingRec, ShipCrops } from "@utility/JSON"
 import type { achievementType, cropsShippedType, generalFormatedItemType, itemsCraftedType, maxMonoType } from "types/displayDataTypes"
 import type { itemsType } from "types/savefile"
-import { GetImages, ValidateKnown } from "./Utils"
+import { GetImages, ValidateKnown } from "./Utils.ts"
 import { Monoculture, Polyculture } from "@media/Achievements";
 
 let CropsAchievements = [{


### PR DESCRIPTION
This pull request updates various import statements across the codebase to explicitly include TypeScript file extensions. This change helps ensure consistent module resolution and compatibility, especially in environments where omitting the `.tsx` or `.ts` extension may cause issues.

**Import Statement Updates:**

* Updated imports in multiple files to explicitly reference `.tsx` or `.ts` extensions for local components and utility modules:
  - Changed `Main`, `Viewer`, and `SkillContainer` imports to use `.tsx` extension in their respective parent files. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2-R2) [[2]](diffhunk://#diff-cca3525d4c9bf293a5d54894ab04a1a2eaa3ba43732a5dc85be2a95d625ff2eeL2-R2) [[3]](diffhunk://#diff-3c1c3a16044bd5c536347ba85f488962684785328bccae713e118999ae573934L2-R2) [[4]](diffhunk://#diff-b054a3e3b0072429755049dfe3e6b2ef2aaf901fdfbdea0475c13d23759b8994L3-R3)
  - Updated utility imports in `parseCraftingItems.ts` and `parseCropItems.ts` to use `.ts` extension. [[1]](diffhunk://#diff-9d7afb0e238d358df3e29b90d7043697bd9f8bffde834e90677ddcba3908599cL4-R4) [[2]](diffhunk://#diff-50cd4a40722e9ebd1a99d30c4314c36e31ec78bd841a286996b0b4d0d907f548L4-R4)