### PR TITLE
Add rarecrow parsing and refactor monster quest logic

### DIFF
--- a/src/Hooks/useLoadSaveFile.tsx
+++ b/src/Hooks/useLoadSaveFile.tsx
@@ -9,6 +9,7 @@ import type {
     specialOrderType 
 } from 'types/savefile.js';
 import type { formattedSaveFileType } from 'types/displayDataTypes';
+import { parseRarecrows } from '@utility/rarecrow-test';
 
 export interface UseLoadSaveFileResult {
     playerData: any;
@@ -62,6 +63,8 @@ const useLoadSaveFile = (): UseLoadSaveFileResult => {
     const getPlayerData = useCallback(() => { 
         //getting players 
         if(!fileData) return;
+        console.log(fileData)		
+
         let player = fileData.SaveGame.player;
         let farmHands: playerType[] = [];
         const gameVersion = fileData.SaveGame.gameVersion;
@@ -86,6 +89,7 @@ const useLoadSaveFile = (): UseLoadSaveFileResult => {
             setError("Couldn't find museum collection data");
             return;
         }
+
         let collectionStatus = GetCollection(museumLocation)
         let specialRequests: specialOrderType = fileData.SaveGame.completedSpecialOrders;
         let availableSpecialRequests: specialOrderType = fileData.SaveGame.availableSpecialOrders;
@@ -103,6 +107,8 @@ const useLoadSaveFile = (): UseLoadSaveFileResult => {
                 availableSpecialRequests: availableSpecialRequests
             })
         }
+        const parsedRarecrows = parseRarecrows('xsi', fileData.SaveGame, players);
+        console.log("Parsed Rarecrows:", parsedRarecrows);
 
         setPlayerData(players)
     }, [fileData])

--- a/src/Utility/rarecrow-test.ts
+++ b/src/Utility/rarecrow-test.ts
@@ -1,0 +1,85 @@
+export type RarecrowRet = string[]; // array of unique parentSheetIndex values found
+
+// Recursive function to search through any object for rarecrows
+function findRarecrowsInObject(obj: any, path: string = ""): any[] {
+	const rarecrows: any[] = [];
+	if (!obj || typeof obj !== "object") return rarecrows;
+
+	// Check if this object itself is a rarecrow
+	if (obj.name === "Rarecrow" && obj.parentSheetIndex) {
+        console.log(`%c Found Rarecrow at path: ${path} 
+            with parentSheetIndex: ${obj.parentSheetIndex}, full data: ${JSON.stringify(obj)}`, 'color: #00FF00');
+		rarecrows.push({
+			...obj,
+			foundAt: path,
+			context: "direct",
+		});
+	}
+
+	for (const [key, value] of Object.entries(obj)) {
+		const currentPath = path ? `${path}.${key}` : key;
+
+		if (value && typeof value === "object") {
+			// If it's an array, check each item
+			if (Array.isArray(value)) {
+				value.forEach((item, index) => {
+					if (item && typeof item === "object") {
+						rarecrows.push(
+							...findRarecrowsInObject(item, `${currentPath}[${index}]`),
+						);
+					}
+				});
+			} else {
+				// If it's an object, recurse into it
+				rarecrows.push(...findRarecrowsInObject(value, currentPath));
+			}
+		}
+	}
+
+	return rarecrows;
+}
+
+export function parseRarecrows(
+	prefix: string,
+	SaveGame: any,
+	player: any,
+): RarecrowRet {
+	/*
+		SCANS THE ENTIRE SAVE FILE for anything rarecrow-related.
+		This is a comprehensive search that will find rarecrows anywhere in the save data.
+	*/
+
+	try {
+		let rarecrowsSet = new Set<string>();
+
+		// Search through the entire SaveGame object
+		const allRarecrows = findRarecrowsInObject(SaveGame, "SaveGame");
+
+		// Also search through player object if provided
+		if (player) {
+			const playerRarecrows = findRarecrowsInObject(player, "Player");
+			allRarecrows.push(...playerRarecrows);
+
+			// Also specifically check player inventory
+			if (player.items && player.items.item) {
+				const inventoryRarecrows = findRarecrowsInObject(
+					player.items,
+					"Player.items",
+				);
+				allRarecrows.push(...inventoryRarecrows);
+			}
+		}
+
+		// Process all found rarecrows
+		allRarecrows.forEach((rarecrow) => {
+			const rarecrowType = rarecrow.parentSheetIndex.toString();
+			rarecrowsSet.add(rarecrowType);
+		});
+
+		return Array.from(rarecrowsSet);
+	} catch (err) {
+		if (err instanceof Error)
+			throw new Error(`Error in parseRarecrows: ${err.message}`);
+		throw new Error(`Error in parseRarecrows: ${err}`);
+	}
+}

--- a/src/hooks/useLoadSaveFile.tsx
+++ b/src/hooks/useLoadSaveFile.tsx
@@ -9,6 +9,7 @@ import type {
     specialOrderType 
 } from 'types/savefile.js';
 import type { formattedSaveFileType } from 'types/displayDataTypes';
+import { parseRarecrows } from '@utility/rarecrow-test';
 
 export interface UseLoadSaveFileResult {
     playerData: any;
@@ -62,6 +63,8 @@ const useLoadSaveFile = (): UseLoadSaveFileResult => {
     const getPlayerData = useCallback(() => { 
         //getting players 
         if(!fileData) return;
+        console.log(fileData)		
+
         let player = fileData.SaveGame.player;
         let farmHands: playerType[] = [];
         const gameVersion = fileData.SaveGame.gameVersion;
@@ -86,6 +89,7 @@ const useLoadSaveFile = (): UseLoadSaveFileResult => {
             setError("Couldn't find museum collection data");
             return;
         }
+
         let collectionStatus = GetCollection(museumLocation)
         let specialRequests: specialOrderType = fileData.SaveGame.completedSpecialOrders;
         let availableSpecialRequests: specialOrderType = fileData.SaveGame.availableSpecialOrders;
@@ -103,6 +107,8 @@ const useLoadSaveFile = (): UseLoadSaveFileResult => {
                 availableSpecialRequests: availableSpecialRequests
             })
         }
+        const parsedRarecrows = parseRarecrows('xsi', fileData.SaveGame, players);
+        console.log("Parsed Rarecrows:", parsedRarecrows);
 
         setPlayerData(players)
     }, [fileData])

--- a/src/types/savefile.ts
+++ b/src/types/savefile.ts
@@ -119,6 +119,10 @@ type buildingIndoorsType = {
     farmhand: playerType | null,
 }
 
+type numberArrayType = {
+    int: number[]
+}
+
 export type playerType = {
     name: string,
     forceOneTileWide: boolean,
@@ -142,7 +146,7 @@ export type playerType = {
     furnitureOwned: string,
     activeDialogueEvents: string,
     secretNotesSeen: string,
-    achievements: string,
+    achievements: numberArrayType,
     specialBigCraftables: string,
     mailForTomorrow: string,
     mailbox: string,
@@ -439,7 +443,12 @@ type statsType = {
     ItemsShipped: number,
     SeedsSown: number,
     IndividualMoneyEarned: number,
-    specificMonstersKilled: specificMonstersKilledType
+    specificMonstersKilled: specificMonstersKilledType,
+    Values: statValueType,
+}
+
+export type statValueType = {
+    item: itemsType[]
 }
 
 type specificMonstersKilledType = {


### PR DESCRIPTION
Introduced a new utility (rarecrow-test.ts) to recursively parse rarecrows from save data and integrated it into useLoadSaveFile. Refactored monster quest logic to use a new GetMonsterQuests parser and improved slimesKilled calculation. Updated types to support new data structures and cleaned up unused code in Utility/index.tsx.